### PR TITLE
update pydata discord url

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -26,7 +26,7 @@ website:
       - icon: twitter-x
         href: https://twitter.com/pydatanyc
       - icon: discord
-        href: https://discord.gg/ffnmygKf4T
+        href: https://discord.gg/RxtaZvxYWM
 
 format:
   html:


### PR DESCRIPTION
As discussed in weekly connect, update the pydata Discord link to point to main Pydata group, rather than "Pydata nyc" discord.  There are more people and community at the main group and we can meet in #nyc