### PR TITLE
bugfix: added back CNAME file

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+nyc.pydata.org


### PR DESCRIPTION
Adding back CNAME to point dns as was accidentally deleted